### PR TITLE
Validate label descriptions, and use shorter label descriptions for effort labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js: lts/*
 
-script: ./apply.sh
+script: 
+  - node validate.js
+  - ./apply.sh
 
 env:
   global:

--- a/config.js
+++ b/config.js
@@ -216,17 +216,17 @@ module.exports = [
     labels: [
       {
         name: '🕔 days',
-        description: 'A few unknowns, but we roughly know what’s involved. We’d expect it to take less than a week to resolve. May be a good thing to pair on.',
+        description: 'A few unknowns, but we roughly know what’s involved.',
         aliases: ['Effort: days']
       },
       {
         name: '🕔 hours',
-        description: 'A well understood issue which we expect to take less than a day to resolve. Could be something that community could be involved in (eg. first timer issues).',
+        description: 'A well understood issue which we expect to take less than a day to resolve.',
         aliases: ['Effort: hours']
       },
       {
         name: '🕔 weeks',
-        description: 'This is complicated and will require a lot of effort from the team, taking more than a week to resolve. May need breaking down into smaller pieces of work.',
+        description: 'This is complicated and will require a lot of effort from the team.',
         aliases: ['Effort: weeks']
       }
     ]

--- a/validate.js
+++ b/validate.js
@@ -1,0 +1,14 @@
+const labels = require('./labels.js')
+let errors = []
+
+labels.forEach(label => {
+  if (label.description && label.description.length > 100) {
+    errors.push(`- Description for "${label.name}" exceeds 100 characters`);
+  }
+})
+
+if (errors.length) {
+  console.log("Validation failed:")
+  console.log(errors.join("\n"));
+  process.exit(1);
+}


### PR DESCRIPTION
If a label description exceeds 100 characters, the call to the GitHub API to patch the label will fail, which means github-label-sync will fail with the error:

```
GitHub Error:
PATCH /repos/alphagov/design-system-team-internal/labels/effort%3A%20days
422: Validation Failed
```

Validating the label descriptions first will catch this when doing a dry-run.

We also need to shorten the description for the days, hours and weeks labels.