### PR TITLE
Update instances of `master` to `main`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js: lts/*
 
-script: 
+script:
   - node validate.js
   - ./apply.sh
 
@@ -15,4 +15,4 @@ deploy:
   # For some reason, we have to explicitly call the script using bash when deploying
   script: env APPLY=true bash ./apply.sh
   on:
-    branch: master
+    branch: main

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ node preview.js
 
 When a pull request is created, you will be able to see a preview of the changes that will be made to each repository in the build log in Travis CI.
 
-Once the pull request has been merged to master, those changes will be applied.
+Once the pull request has been merged to `main`, those changes will be applied.
 
 Labels that are not included in this config will not be affected. This also means that removing a label from the config will not remove it from any repositories.
 


### PR DESCRIPTION
Part of https://github.com/alphagov/design-system-team-internal/issues/432 and https://github.com/alphagov/design-system-team-internal/issues/428

This PR:

- updates documentation to replace all instances of `master` with `main`
- updates Travis config to refer to `master` instead of `main`