### PR TITLE
Add epic theme labels and remove blocked labels

### DIFF
--- a/config.js
+++ b/config.js
@@ -274,10 +274,6 @@ module.exports = [
     group: 'Others',
     labels: [
       {
-        name: 'blocked',
-        color: '0b0c0c'
-      },
-      {
         name: 'breaking change',
         color: '5319e7',
         aliases: ['breaking-change']

--- a/config.js
+++ b/config.js
@@ -178,6 +178,32 @@ module.exports = [
   },
 
   {
+    group: 'Themes',
+    labels: [
+      {
+        name: 'small story',
+        color: '0B0C0C'
+      },
+      {
+        name: 'technical enablement',
+        color: 'DA7F25'
+      },
+      {
+        name: 'refining team processes',
+        color: 'A15E8F'
+      },
+      {
+        name: 'building the community',
+        color: '5EA18E'
+      },
+      {
+        name: 'contribution or major iteration',
+        color: '6B8094'
+      }
+    ]
+  },
+
+  {
     group: 'Technical',
     color: '5bffd8',
     labels: [


### PR DESCRIPTION
As part of our change to using kanban, we're now working in epics, with 4 epics running at any one time and each epic from one of 4 themes:

- technical enablement
- refining team processes
- building the community
- a contribution or major iteration of an existing style, component or pattern

We'll use these labels on the epics in the backlog so that we know which theme they belong to.

We also don’t need the blocked label any more, as we track blocked stories using a column on our kanban board.

Because of the way this tool is currently set up, removing the label will not remove it from repos – we'll need to remove the label from each repo manually. However we still need to remove it otherwise it will be re-added the next time we change labels.