### PR TITLE
Set granular token permissions for GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: Test GitHub labels
 
 on: pull_request
 
+permissions:
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Following best practise, grant the GITHUB_TOKEN only the required permissions – which in this case is write access on pull requests in order to be able to add the comment to the PR.

This also allows us to change the default permissions for workflows to 'Read repository contents' only.