### PR TITLE
Use node-version-file input to specify node version in GitHub Actions

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -15,7 +15,7 @@ jobs:
       - id: nvm
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
       - name: "Setup Node v${{ steps.nvm.outputs.NVMRC }}"
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
 

--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -12,12 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - id: nvm
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      - name: "Setup Node v${{ steps.nvm.outputs.NVMRC }}"
+      - name: "Setup Node"
         uses: actions/setup-node@v3
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies from npm
         run: npm ci

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       - id: nvm
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
       - name: "Setup Node v${{ steps.nvm.outputs.NVMRC }}"
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,12 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - id: nvm
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      - name: "Setup Node v${{ steps.nvm.outputs.NVMRC }}"
+      - name: "Setup Node"
         uses: actions/setup-node@v3
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies from npm
         run: npm ci


### PR DESCRIPTION
actions/setup-node v2.5.0 and above support reading a .nvmrc file itself [[1]]. This lets us simplify our code.

[1]: https://github.com/actions/setup-node/releases/tag/v2.5.0