### PR TITLE
Update repo labels

### DIFF
--- a/config.js
+++ b/config.js
@@ -275,6 +275,10 @@ export default [
         aliases: ['bug']
       },
       {
+        name: 'main epic',
+        color: '0b0c0c'
+      },
+      {
         name: 'epic',
         color: '0b0c0c'
       },
@@ -310,6 +314,10 @@ export default [
       {
         name: 'tech debt',
         color: '5bffd8'
+      },
+      {
+        name: 'design system day',
+        color: '5319e7'
       },
       {
         name: 'prototype kit',


### PR DESCRIPTION
Added labels for:
- 'main epic' as we need a way to differentiate between main epics like [Design System Day 2023](https://github.com/alphagov/govuk-design-system/issues/2564) and the sub-epics like [Procure platforms for Design System Day 2023](https://github.com/alphagov/design-system-team-internal/issues/682). I can then filter the sprint planning board to only display sub-epics
- 'design system day' for event related activities