### PR TITLE
Add 'Service navigation' component

### DIFF
--- a/config.js
+++ b/config.js
@@ -45,6 +45,7 @@ export default [
       'phase banner',
       'radios',
       'select',
+      'service navigation',
       'skip link',
       'summary list',
       'table',


### PR DESCRIPTION
Adds a label for the 'Service navigation' component.

## Thoughts

The PR doesn't add anything for the 'Navigate a service' pattern as the state of the labels for the patterns looks a little unclear (quite a few of them are missing, some labels seem to refer that patterns that are no longer in our Patterns lists), so this should be the object of [its own piece of work](https://github.com/alphagov/design-system-team-labels/issues/41).