### PR TITLE
Update accessibility concern description

### DIFF
--- a/config.js
+++ b/config.js
@@ -228,7 +228,7 @@ export default [
       {
         name: 'accessibility concern',
         color: 'D93F0B',
-        description: 'Any bug, feature request or question about the accessibility of a portion of a product',
+        description: 'Bug, feature request or question about the accessibility of a portion of a product (not a WCAG fail)',
         aliases: ['accessibility-concern']
       },
       {


### PR DESCRIPTION
Make it clear that a 'concern' in this context means something that could affect accessibility but isn't known to be a failure under WCAG.

Original change, slightly reformatted, by @selfthinker 